### PR TITLE
Do not match on complete error message of checkmate in tests

### DIFF
--- a/tests/testthat/test_stack_thresh.R
+++ b/tests/testthat/test_stack_thresh.R
@@ -22,7 +22,7 @@ test_that("mean_stack_thresh works", {
   img_thresh_mask <- med_stack_thresh(img, "Triangle")
   expect_equal(round(mean(img_thresh_mask, na.rm = TRUE), 3), 23.583)
   expect_error(med_stack_thresh(img + 2 ^ 32, "Triangle"),
-               "All elements must be <=")
+               "<=")
   img_thresh_mask <- mean_stack_thresh(img + 2 ^ 30, "Otsu")
   expect_equal(round(mean(img_thresh_mask, na.rm = TRUE)), 24 + 2 ^ 30)
   const_arr <- array(2, dim = rep(2, 3))


### PR DESCRIPTION
Hi there, 

While preparing a new release of checkmate, I improved some error messages to provide additional information, e.g. the location of the first missing value in a vector. This unfortunately broke a unit test in your package. This PR should fix the test in question. Instead of matching on the complete sentence, the new pattern just matches the comparison chars. 
I currently see no better way around this to make this more future-proof :disappointed: ...

It would be great if you could release a new version to CRAN in the next few weeks.

Best, 
Michel