### PR TITLE
Fix for upcoming purrr 1.2.0 release

### DIFF
--- a/vignettes/finding-thresholds.Rmd
+++ b/vignettes/finding-thresholds.Rmd
@@ -62,7 +62,7 @@ thresh_methods <- c(
   "Li", "Mean", "MinErrorI", "Minimum", "Moments", "Otsu",
   "Percentile", "RenyiEntropy", "Shanbhag", "Triangle"
 )
-thresholds <- purrr::map_chr(thresh_methods, ~ auto_thresh(x, .)) %>%
+thresholds <- purrr::map_dbl(thresh_methods, ~ auto_thresh(x, .)) %>%
   tibble(method = thresh_methods, threshold = .)
 print(thresholds)
 ```


### PR DESCRIPTION
`map_chr()` no longer automatically coerces its inputs to strings since that's a common source of errors, as it was here :)